### PR TITLE
Bugfixes in debian/dirs und templates/common-pammount

### DIFF
--- a/README
+++ b/README
@@ -12,5 +12,6 @@ on the "Linux Musterlösung".
 
 Tested on
 
-  * Ubuntu 12.04LTS beta2
-  * Linux Mint 12 "Lisa" (based on ubuntu 11.10)
+  * Ubuntu 14.04 LTS
+ 
+Note: Not working on Ubuntu < 14.04!

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linuxmuster-client-auth (0.5-trusty3) trusty; urgency=low
+
+  * Bugfix: Put /etc/lightdm/lightdm.conf.d in debian/dirs
+  * Bugfix: Update template for pam.d/common-pammount to not override
+    config files from linuxmuster-client-shares druring dist-upgrade.
+
+ -- Dominik Förderer <dominik-foerderer@windeck-gymnasium.de>  Thu, 15 May 2014 13:22:06 +0100
+
 linuxmuster-client-auth (0.5-trusty2) trusty; urgency=low
 
   * Moved lightdm config in the templates from /etc/lightdm/lightdm.conf to

--- a/debian/dirs
+++ b/debian/dirs
@@ -2,3 +2,4 @@
 /etc/linuxmuster-client/post-mount.d
 /etc/linuxmuster-client/pre-umount.d
 /etc/linuxmuster-client/post-umount.d
+/etc/lightdm/lightdm.conf.d

--- a/var/lib/linuxmuster-client-auth/templates/etc/pam.d/common-pammount
+++ b/var/lib/linuxmuster-client-auth/templates/etc/pam.d/common-pammount
@@ -19,5 +19,5 @@
 # for configuration details about different login programs see
 # /usr/share/doc/libpam-mount/README.Debian.gz
 #
-# Diese Datei ist leer
-
+auth		required pam_mount.so
+session		optional pam_mount.so


### PR DESCRIPTION
Änderungen + Erklärung:
- README angepasst, da Ubuntuversionen < 14.04 aufgrund der partiellen Umstellung auf systemd nicht mehr mit dieser Version linuxmuster-client-auth kompatibel sind
- Bei der Erstinstallation des Pakets muss das nicht vorhandene Verzeichnis /etc/lightdm/lightdm.conf.d angelegt werden, sonst bricht die Installation mit einer Fehlermeldung ab
- Beim dist-upgrade wird eine vom Paket linuxmuster-client-shares angepasste Version der common-pammount überschrieben, wodurch zwar die Anmeldung noch funktioniert aber das Profilkopieren nicht mehr!

--> Ein deb-Paket mit diesen Änderungen befindet sich schon im Repo unter trusty-testing
